### PR TITLE
Parameters & accelerometer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A node.js control library for the [Crazyflie](http://wiki.bitcraze.se/projects:c
 
 [![Dependencies](https://david-dm.org/ceejbot/aerogel.png)](https://david-dm.org/ceejbot/aerogel) [![NPM version](https://badge.fury.io/js/aerogel.png)](http://badge.fury.io/js/aerogel)
 
+[![NPM](http://nodei.co/npm/aerogel.png)](http://nodei.co/npm/aerogel/)
 
 ## Installation
 

--- a/examples/telemetry.js
+++ b/examples/telemetry.js
@@ -29,8 +29,17 @@ function bail()
 
 copter.on('ready', function()
 {
-	console.log('got all telemetry & parameters; shutting down');
-	shutdown();
+	console.log('got all telemetry & parameters');
+
+	var params = copter.driver.parameters.all();
+	// console.log(params);
+
+	copter.driver.parameters.get('cpu.id0')
+	.then(function(value)
+	{
+		console.log('cpu.id0 ==', value);
+		shutdown();
+	});
 });
 
 function shutdown()
@@ -53,6 +62,8 @@ function shutdown()
 	})
 	.done();
 }
+
+setTimeout(shutdown, 30000);
 
 driver.findCopters()
 .then(function(copters)

--- a/examples/telemetry.js
+++ b/examples/telemetry.js
@@ -2,17 +2,15 @@ var Aerogel = require('../index');
 
 var driver = new Aerogel.CrazyDriver();
 var copter = new Aerogel.Copter(driver);
+var params;
 process.on('SIGINT', bail);
 
 console.log('just connecting & sitting to log some telemetry info...');
 
 function bail()
 {
-	return copter.land()
-	.then(function()
-	{
-		return copter.shutdown();
-	})
+	console.log('entered bail()');
+	return copter.shutdown()
 	.then(function()
 	{
 		return process.exit(0);
@@ -26,44 +24,7 @@ function bail()
 	.done();
 }
 
-
-copter.on('ready', function()
-{
-	console.log('got all telemetry & parameters');
-
-	var params = copter.driver.parameters.all();
-	// console.log(params);
-
-	copter.driver.parameters.get('cpu.id0')
-	.then(function(value)
-	{
-		console.log('cpu.id0 ==', value);
-		shutdown();
-	});
-});
-
-function shutdown()
-{
-	copter.shutdown()
-	.then(function(response)
-	{
-		console.log(response);
-		process.exit(0);
-	})
-	.fail(function(err)
-	{
-		console.log(err);
-		copter.shutdown()
-		.then(function(response)
-		{
-			console.log(response);
-			process.exit(1);
-		});
-	})
-	.done();
-}
-
-setTimeout(shutdown, 30000);
+setTimeout(bail, 30000);
 
 driver.findCopters()
 .then(function(copters)
@@ -81,5 +42,33 @@ driver.findCopters()
 .then(function(uri)
 {
 	return copter.connect(uri);
+})
+.then(function()
+{
+	console.log('got all telemetry & parameters');
+
+	params = copter.driver.parameters.all();
+	console.log(params);
+	return copter.driver.parameters.get('pid_attitude.yaw_kd');
+})
+.then(function(value)
+{
+	console.log('pid_attitude.yaw_kd:', value);
+	return copter.shutdown();
+})
+.then(function(response)
+{
+	console.log('Shutdown complete.');
+	process.exit(0);
+})
+.fail(function(err)
+{
+	console.log(err);
+	copter.shutdown()
+	.then(function(response)
+	{
+		console.log(response);
+		process.exit(1);
+	});
 })
 .done();

--- a/lib/copter.js
+++ b/lib/copter.js
@@ -63,7 +63,7 @@ Copter.prototype.connect = function(uri)
 	})
 	.done();
 
-	return deferred.promise();
+	return deferred.promise;
 };
 
 Copter.prototype.takeoff = function()
@@ -217,7 +217,7 @@ Copter.prototype.buildStates = function()
 
 	this.copterStates.onChange = function(current, previous)
 	{
-		console.log('STATE CHANGE:', previous, '--->', current);
+		console.log('STATE CHANGE:', previous, '-->', current);
 	};
 };
 

--- a/lib/copter.js
+++ b/lib/copter.js
@@ -49,8 +49,9 @@ Copter.prototype.connect = function(uri)
 	self.driver.connect(uri)
 	.then(function()
 	{
-		self.driver.onStabilizerTelemetry(self.handleStabilizerTelemetry.bind(self));
-		self.driver.onMotorTelemetry(self.handleMotorTelemetry.bind(self));
+		self.driver.telemetry.subscribe('motor', self.handleMotorTelemetry.bind(self));
+		self.driver.telemetry.subscribe('stabilizer', self.handleStabilizerTelemetry.bind(self));
+		self.driver.telemetry.subscribe('accelerometer', self.handleAccTelemetry.bind(self));
 		self.copterStates.ready();
 		self.emit('ready');
 		deferred.resolve('ready');
@@ -357,6 +358,11 @@ Copter.prototype.__defineSetter__('thrust', Copter.prototype.setThrust);
 Copter.prototype.handleMotorTelemetry = function(data)
 {
 	// console.log('motor:', data);
+};
+
+Copter.prototype.handleAccTelemetry = function(data)
+{
+	// console.log('acc:', data);
 };
 
 Copter.prototype.shutdown = function()

--- a/lib/copter.js
+++ b/lib/copter.js
@@ -42,23 +42,28 @@ util.inherits(Copter, events.EventEmitter);
 
 Copter.prototype.connect = function(uri)
 {
-	var self = this;
+	var self = this,
+		deferred = P.defer();
 	self.copterStates.connect();
 
-	return self.driver.connect(uri)
+	self.driver.connect(uri)
 	.then(function()
 	{
 		self.driver.onStabilizerTelemetry(self.handleStabilizerTelemetry.bind(self));
 		self.driver.onMotorTelemetry(self.handleMotorTelemetry.bind(self));
 		self.copterStates.ready();
 		self.emit('ready');
+		deferred.resolve('ready');
 	})
 	.fail(function(err)
 	{
 		console.log(err);
 		self.emit('error', err);
+		deferred.reject(err);
 	})
 	.done();
+
+	return deferred.promise();
 };
 
 Copter.prototype.takeoff = function()
@@ -66,8 +71,6 @@ Copter.prototype.takeoff = function()
 	// take off & hover.
 	var self = this,
 		deferred = P.defer();
-
-	console.log('takeoff()');
 
 	this.copterStates.takeoff();
 	this.pulseTimer = setInterval(this.pulse.bind(this), 100);
@@ -214,7 +217,7 @@ Copter.prototype.buildStates = function()
 
 	this.copterStates.onChange = function(current, previous)
 	{
-		console.log('entering', current, 'from', previous);
+		console.log('STATE CHANGE:', previous, '--->', current);
 	};
 };
 

--- a/lib/copter.js
+++ b/lib/copter.js
@@ -48,7 +48,6 @@ Copter.prototype.connect = function(uri)
 	return self.driver.connect(uri)
 	.then(function()
 	{
-		console.log('driver connected');
 		self.driver.onStabilizerTelemetry(self.handleStabilizerTelemetry.bind(self));
 		self.driver.onMotorTelemetry(self.handleMotorTelemetry.bind(self));
 		self.copterStates.ready();

--- a/lib/crazydriver.js
+++ b/lib/crazydriver.js
@@ -243,14 +243,15 @@ CrazyDriver.prototype.telemetryReady = function()
 
 CrazyDriver.prototype.onStabilizerTelemetry = function(subfunc)
 {
-	this.telemetry.addSubscriber(subfunc, 'stabilizer');
+	this.telemetry.subscribe('stabilizer', subfunc);
 };
 
 CrazyDriver.prototype.onMotorTelemetry = function(subfunc)
 {
-	this.telemetry.addSubscriber(subfunc, 'motor');
+	this.telemetry.subscribe('motor', subfunc);
 };
 
+// ---------------------
 // now the heavy lifting
 
 CrazyDriver.prototype.requestTOC = function(which)

--- a/lib/crazydriver.js
+++ b/lib/crazydriver.js
@@ -1,5 +1,7 @@
 // Crazy Real Time Protocol Driver
 // This module knows how to format messages for the crazy radio and the copter.
+// There's some repetition because the emphasis is on provding a clear, readable
+// API to higher levels.
 
 var
 	_           = require('lodash'),
@@ -9,10 +11,11 @@ var
 	P           = require('p-promise'),
 	Crazyradio  = require('./crazyradio'),
 	Crazypacket = require('./crazypacket'),
+	Parameters  = require('./parameters'),
 	Telemetry   = require('./telemetry')
 	;
 
-function CrazyDriver(name)
+var CrazyDriver = module.exports = function CrazyDriver(name)
 {
 	events.EventEmitter.call(this);
 
@@ -20,7 +23,8 @@ function CrazyDriver(name)
 	this.channel  = 2;
 	this.datarate = 2;
 	this.telemetry = new Telemetry(this);
-}
+	this.parameters = new Parameters(this);
+};
 util.inherits(CrazyDriver, events.EventEmitter);
 
 CrazyDriver.prototype.findCopters = function()
@@ -31,7 +35,7 @@ CrazyDriver.prototype.findCopters = function()
 	var results;
 
 	return self.radio.setupRadio()
-	.then(self.radio.setAckRetryCount(1))
+	.then(function() { return self.radio.setAckRetryCount(1); })
 	.then(function() { return self.scanAtRate(0); })
 	.then(function(res1)
 	{
@@ -87,9 +91,7 @@ CrazyDriver.prototype.scanAtRate = function(datarate)
 	{
 		var copters = [];
 		for (var i = 0; i < result.length; i++)
-		{
 			copters.push(util.format('radio://1/%d/%s', result[i], CrazyDriver.DATARATE[datarate]));
-		}
 
 		return copters;
 	});
@@ -127,7 +129,8 @@ CrazyDriver.prototype.connect = function(uri)
 	return self.radio.setupRadio(null, self.channel, self.datarate)
 	.then(function()
 	{
-		return self.startTelemetry();
+		self.fetchParameters(); // background task
+		return self.startTelemetry(); // completion required for flight
 	});
 };
 
@@ -174,23 +177,69 @@ CrazyDriver.prototype.setpoint = function(roll, pitch, yaw, thrust)
 };
 
 // parameter functions: get list, set, get
-// telemetry aka logging functions
+
+CrazyDriver.prototype.fetchParameters = function()
+{
+	this.radio.addListener('param', this.parameters.handlePacket.bind(this.parameters));
+	this.requestTOC(Crazypacket.Ports.PARAM);
+};
+
+CrazyDriver.prototype.getParameter = function(param)
+{
+	var packet = new Crazypacket();
+	packet.port = Crazypacket.Ports.PARAM;
+	packet.channel = Crazypacket.Channels.PARAM_READ;
+	packet.writeByte(param.id);
+	packet.endPacket();
+
+	return this.radio.sendPacket(packet);
+};
+
+CrazyDriver.prototype.setParameter = function(param, value)
+{
+	var packet = new Crazypacket();
+	packet.port = Crazypacket.Ports.PARAM;
+	packet.channel = Crazypacket.Channels.PARAM_WRITE;
+
+	packet.writeByte(param.id)
+	.writeType(param.type, value)
+	.endPacket();
+
+	return this.radio.sendPacket(packet);
+};
+
+// telemetry, which the Crazy protocol calls "logging"
 
 CrazyDriver.prototype.startTelemetry = function()
 {
+	var self = this;
 	this.telemetryDeferred = P.defer();
 
 	this.radio.addListener('logging', this.telemetry.handlePacket.bind(this.telemetry));
-	this.requestTOC();
+
+	var packet = new Crazypacket();
+	packet.port = Crazypacket.Ports.LOGGING;
+	packet.channel = Crazypacket.Channels.SETTINGS;
+	packet.writeByte(Crazypacket.Commands.RESET_LOGGING);
+	packet.endPacket();
+
+	this.radio.sendPacket(packet)
+	.then(function()
+	{
+		this.requestTOC(Crazypacket.Ports.LOGGING);
+	});
 
 	return this.telemetryDeferred.promise;
 };
 
 CrazyDriver.prototype.telemetryReady = function()
 {
+	if (!this.telemetryDeferred) return;
 	this.telemetryDeferred.resolve('OK');
 	this.telemetryDeferred = undefined;
 };
+
+// call these to add listeners; I really don't like this API though.
 
 CrazyDriver.prototype.onStabilizerTelemetry = function(subfunc)
 {
@@ -202,33 +251,35 @@ CrazyDriver.prototype.onMotorTelemetry = function(subfunc)
 	this.telemetry.addSubscriber(subfunc, 'motor');
 };
 
-CrazyDriver.prototype.requestTOC = function()
-{
-	var self = this;
+// now the heavy lifting
 
+CrazyDriver.prototype.requestTOC = function(which)
+{
 	var packet = new Crazypacket();
-	packet.port = Crazypacket.Ports.LOGGING;
-	packet.channel = Crazypacket.Channels.SETTINGS;
-	packet.writeByte(Crazypacket.Commands.RESET_LOGGING);
+	packet.port = which;
+	packet.channel = Crazypacket.Channels.TOC;
+	packet.writeByte(Crazypacket.Commands.GET_INFO);
 	packet.endPacket();
 
-	return self.radio.sendPacket(packet)
-	.then(function()
-	{
-		packet = new Crazypacket();
-		packet.port = Crazypacket.Ports.LOGGING;
-		packet.channel = Crazypacket.Channels.TOC;
-		packet.writeByte(Crazypacket.Commands.GET_INFO);
-		packet.endPacket();
-
-		return self.radio.sendPacket(packet);
-	});
+	return this.radio.sendPacket(packet);
 };
+
+// request details about a specific parameter or telemetry item
 
 CrazyDriver.prototype.requestTelemetryElement = function(id)
 {
+	return this.requestTOCItem(Crazypacket.Ports.LOGGING, id);
+};
+
+CrazyDriver.prototype.requestParameter = function(id)
+{
+	return this.requestTOCItem(Crazypacket.Ports.PARAM, id);
+};
+
+CrazyDriver.prototype.requestTOCItem = function(port, id)
+{
 	var packet = new Crazypacket();
-	packet.port = Crazypacket.Ports.LOGGING;
+	packet.port = port;
 	packet.channel = Crazypacket.Channels.TOC;
 	packet.writeByte(Crazypacket.Commands.GET_ELEMENT);
 	if (id)
@@ -237,6 +288,9 @@ CrazyDriver.prototype.requestTelemetryElement = function(id)
 
 	return this.radio.sendPacket(packet);
 };
+
+// Create a telemetry block, aka a group of sensor readings that
+// get emitted by the copter periodically.
 
 CrazyDriver.prototype.createTelemetryBlock = function(block)
 {
@@ -272,9 +326,7 @@ CrazyDriver.prototype.enableTelemetryBlock = function(block)
 
 CrazyDriver.prototype.handleAck = function(buf)
 {
-	// TODO record ack stats
+	// TODO record ack stats-- dropped packets etc
 	var ack = new Crazypacket.RadioAck(buf);
 	return P(ack);
 };
-
-module.exports = CrazyDriver;

--- a/lib/crazydriver.js
+++ b/lib/crazydriver.js
@@ -204,7 +204,7 @@ CrazyDriver.prototype.getParameter = function(param)
 	var packet = new Crazypacket();
 	packet.port = Crazypacket.Ports.PARAM;
 	packet.channel = Crazypacket.Channels.PARAM_READ;
-	packet.writeByte(param.id);
+	packet.writeByte(param);
 	packet.endPacket();
 
 	return this.radio.sendPacket(packet);

--- a/lib/crazydriver.js
+++ b/lib/crazydriver.js
@@ -125,12 +125,18 @@ CrazyDriver.prototype.connect = function(uri)
 		}
 	}
 
+	this.radio.addListener('logging', this.telemetry.handlePacket.bind(this.telemetry));
+	this.radio.addListener('param', this.parameters.handlePacket.bind(this.parameters));
+
 	this.channel = parseInt(pieces[1], 10);
 	return self.radio.setupRadio(null, self.channel, self.datarate)
 	.then(function()
 	{
-		self.fetchParameters(); // background task
 		return self.startTelemetry(); // completion required for flight
+	})
+	.then(function()
+	{
+		return self.fetchParameters();
 	});
 };
 
@@ -180,8 +186,17 @@ CrazyDriver.prototype.setpoint = function(roll, pitch, yaw, thrust)
 
 CrazyDriver.prototype.fetchParameters = function()
 {
-	this.radio.addListener('param', this.parameters.handlePacket.bind(this.parameters));
+	var self = this;
+	this.parametersDeferred = P.defer();
 	this.requestTOC(Crazypacket.Ports.PARAM);
+	return this.parametersDeferred.promise;
+};
+
+CrazyDriver.prototype.parametersDone = function()
+{
+	if (!this.parametersDeferred) return;
+	this.parametersDeferred.resolve('OK');
+	this.parametersDeferred = undefined;
 };
 
 CrazyDriver.prototype.getParameter = function(param)
@@ -212,10 +227,9 @@ CrazyDriver.prototype.setParameter = function(param, value)
 
 CrazyDriver.prototype.startTelemetry = function()
 {
+	console.log('starting telemetry');
 	var self = this;
 	this.telemetryDeferred = P.defer();
-
-	this.radio.addListener('logging', this.telemetry.handlePacket.bind(this.telemetry));
 
 	var packet = new Crazypacket();
 	packet.port = Crazypacket.Ports.LOGGING;
@@ -226,7 +240,7 @@ CrazyDriver.prototype.startTelemetry = function()
 	this.radio.sendPacket(packet)
 	.then(function()
 	{
-		this.requestTOC(Crazypacket.Ports.LOGGING);
+		self.requestTOC(Crazypacket.Ports.LOGGING);
 	});
 
 	return this.telemetryDeferred.promise;

--- a/lib/crazydriver.js
+++ b/lib/crazydriver.js
@@ -254,18 +254,6 @@ CrazyDriver.prototype.telemetryReady = function()
 	this.telemetryDeferred = undefined;
 };
 
-// call these to add listeners; I really don't like this API though.
-
-CrazyDriver.prototype.onStabilizerTelemetry = function(subfunc)
-{
-	this.telemetry.subscribe('stabilizer', subfunc);
-};
-
-CrazyDriver.prototype.onMotorTelemetry = function(subfunc)
-{
-	this.telemetry.subscribe('motor', subfunc);
-};
-
 // ---------------------
 // now the heavy lifting
 

--- a/lib/crazydriver.js
+++ b/lib/crazydriver.js
@@ -12,6 +12,7 @@ var
 	Crazyradio  = require('./crazyradio'),
 	Crazypacket = require('./crazypacket'),
 	Parameters  = require('./parameters'),
+	Protocol    = require('./protocol'),
 	Telemetry   = require('./telemetry')
 	;
 
@@ -162,7 +163,7 @@ CrazyDriver.prototype.setpoint = function(roll, pitch, yaw, thrust)
 		deferred = P.defer();
 
 	var packet = new Crazypacket();
-	packet.port = Crazypacket.Ports.COMMANDER;
+	packet.port = Protocol.Ports.COMMANDER;
 
 	packet.writeFloat(roll)
 		.writeFloat(-pitch)
@@ -188,7 +189,7 @@ CrazyDriver.prototype.fetchParameters = function()
 {
 	var self = this;
 	this.parametersDeferred = P.defer();
-	this.requestTOC(Crazypacket.Ports.PARAM);
+	this.requestTOC(Protocol.Ports.PARAM);
 	return this.parametersDeferred.promise;
 };
 
@@ -202,8 +203,8 @@ CrazyDriver.prototype.parametersDone = function()
 CrazyDriver.prototype.getParameter = function(param)
 {
 	var packet = new Crazypacket();
-	packet.port = Crazypacket.Ports.PARAM;
-	packet.channel = Crazypacket.Channels.PARAM_READ;
+	packet.port = Protocol.Ports.PARAM;
+	packet.channel = Protocol.Channels.PARAM_READ;
 	packet.writeByte(param);
 	packet.endPacket();
 
@@ -213,8 +214,8 @@ CrazyDriver.prototype.getParameter = function(param)
 CrazyDriver.prototype.setParameter = function(param, value)
 {
 	var packet = new Crazypacket();
-	packet.port = Crazypacket.Ports.PARAM;
-	packet.channel = Crazypacket.Channels.PARAM_WRITE;
+	packet.port = Protocol.Ports.PARAM;
+	packet.channel = Protocol.Channels.PARAM_WRITE;
 
 	packet.writeByte(param.id)
 	.writeType(param.type, value)
@@ -232,15 +233,15 @@ CrazyDriver.prototype.startTelemetry = function()
 	this.telemetryDeferred = P.defer();
 
 	var packet = new Crazypacket();
-	packet.port = Crazypacket.Ports.LOGGING;
-	packet.channel = Crazypacket.Channels.SETTINGS;
-	packet.writeByte(Crazypacket.Commands.RESET_LOGGING);
+	packet.port = Protocol.Ports.LOGGING;
+	packet.channel = Protocol.Channels.SETTINGS;
+	packet.writeByte(Protocol.Commands.RESET_LOGGING);
 	packet.endPacket();
 
 	this.radio.sendPacket(packet)
 	.then(function()
 	{
-		self.requestTOC(Crazypacket.Ports.LOGGING);
+		self.requestTOC(Protocol.Ports.LOGGING);
 	});
 
 	return this.telemetryDeferred.promise;
@@ -272,8 +273,8 @@ CrazyDriver.prototype.requestTOC = function(which)
 {
 	var packet = new Crazypacket();
 	packet.port = which;
-	packet.channel = Crazypacket.Channels.TOC;
-	packet.writeByte(Crazypacket.Commands.GET_INFO);
+	packet.channel = Protocol.Channels.TOC;
+	packet.writeByte(Protocol.Commands.GET_INFO);
 	packet.endPacket();
 
 	return this.radio.sendPacket(packet);
@@ -283,20 +284,20 @@ CrazyDriver.prototype.requestTOC = function(which)
 
 CrazyDriver.prototype.requestTelemetryElement = function(id)
 {
-	return this.requestTOCItem(Crazypacket.Ports.LOGGING, id);
+	return this.requestTOCItem(Protocol.Ports.LOGGING, id);
 };
 
 CrazyDriver.prototype.requestParameter = function(id)
 {
-	return this.requestTOCItem(Crazypacket.Ports.PARAM, id);
+	return this.requestTOCItem(Protocol.Ports.PARAM, id);
 };
 
 CrazyDriver.prototype.requestTOCItem = function(port, id)
 {
 	var packet = new Crazypacket();
 	packet.port = port;
-	packet.channel = Crazypacket.Channels.TOC;
-	packet.writeByte(Crazypacket.Commands.GET_ELEMENT);
+	packet.channel = Protocol.Channels.TOC;
+	packet.writeByte(Protocol.Commands.GET_ELEMENT);
 	if (id)
 		packet.writeByte(id);
 	packet.endPacket();
@@ -310,9 +311,9 @@ CrazyDriver.prototype.requestTOCItem = function(port, id)
 CrazyDriver.prototype.createTelemetryBlock = function(block)
 {
 	var packet = new Crazypacket();
-	packet.port = Crazypacket.Ports.LOGGING;
-	packet.channel = Crazypacket.Channels.SETTINGS;
-	packet.writeByte(Crazypacket.Commands.CREATE_BLOCK)
+	packet.port = Protocol.Ports.LOGGING;
+	packet.channel = Protocol.Channels.SETTINGS;
+	packet.writeByte(Protocol.Commands.CREATE_BLOCK)
 		.writeByte(block.id);
 
 	for (var i = 0; i < block.variables.length; i++)
@@ -329,9 +330,9 @@ CrazyDriver.prototype.createTelemetryBlock = function(block)
 CrazyDriver.prototype.enableTelemetryBlock = function(block)
 {
 	var packet = new Crazypacket();
-	packet.port = Crazypacket.Ports.LOGGING;
-	packet.channel = Crazypacket.Channels.SETTINGS;
-	packet.writeByte(Crazypacket.Commands.START_LOGGING)
+	packet.port = Protocol.Ports.LOGGING;
+	packet.channel = Protocol.Channels.SETTINGS;
+	packet.writeByte(Protocol.Commands.START_LOGGING)
 		.writeByte(block)
 		.writeByte(10) // period
 		.endPacket();

--- a/lib/crazypacket.js
+++ b/lib/crazypacket.js
@@ -62,6 +62,46 @@ Crazypacket.Commands =
 // This is sugar so you never have to resize your buffer & to track how many
 // bytes we need to write over the radio.
 
+Crazypacket.readType = function(buffer, type, offset)
+{
+	switch(type)
+	{
+	case 'uint8_t':
+		return buffer.readUInt8(offset);
+
+	case 'uint16_t':
+		return buffer.readUInt16(offset);
+
+	case 'uint32_t':
+		return buffer.readUInt32(offset);
+
+	case 'uint64_t':
+		return buffer.readUInt64(offset);
+
+	case 'int8_t':
+		return buffer.readInt8(offset);
+
+	case 'int16_t':
+		return buffer.readInt16(offset);
+
+	case 'int32_t':
+		return buffer.readInt32(offset);
+
+	case 'int64_t':
+		return buffer.readInt64(offset);
+
+	case 'float':
+		return buffer.readFloatLE(offset);
+
+	case 'double':
+		return buffer.readDoubleLE(offset);
+
+	default:
+		// log?
+		return 0;
+	}
+};
+
 
 Crazypacket.prototype.writeType = function(type, value)
 {

--- a/lib/crazypacket.js
+++ b/lib/crazypacket.js
@@ -22,42 +22,6 @@ function Crazypacket(data)
 }
 
 // --------------------------------------------
-// TODO move constants to driver
-
-Crazypacket.Ports =
-{
-	CONSOLE     : 0x00,
-	PARAM       : 0x02,
-	COMMANDER   : 0x03,
-	LOGGING     : 0x05,
-	DEBUGDRIVER : 0x0E,
-	LINKCTRL    : 0x0F,
-	ALL         : 0xFF,
-};
-
-Crazypacket.Channels =
-{
-	TOC:      0,
-	SETTINGS: 1,
-	LOGDATA:  2,
-	PARAM_TOC: 0,
-	PARAM_READ: 1,
-	PARAM_WRITE: 2,
-};
-
-Crazypacket.Commands =
-{
-	CREATE_BLOCK:  0,
-	APPEND_BLOCK:  1,
-	DELETE_BLOCK:  2,
-	START_LOGGING: 3,
-	STOP_LOGGING:  4,
-	RESET_LOGGING: 5,
-	GET_ELEMENT:   0,
-	GET_INFO:      1
-};
-
-// --------------------------------------------
 // chainable write methods
 // This is sugar so you never have to resize your buffer & to track how many
 // bytes we need to write over the radio.

--- a/lib/crazypacket.js
+++ b/lib/crazypacket.js
@@ -21,8 +21,8 @@ function Crazypacket(data)
 	this.pointer = 1;
 }
 
-
 // --------------------------------------------
+// TODO move constants to driver
 
 Crazypacket.Ports =
 {
@@ -39,7 +39,10 @@ Crazypacket.Channels =
 {
 	TOC:      0,
 	SETTINGS: 1,
-	LOGDATA:  2
+	LOGDATA:  2,
+	PARAM_TOC: 0,
+	PARAM_READ: 1,
+	PARAM_WRITE: 2,
 };
 
 Crazypacket.Commands =
@@ -56,6 +59,49 @@ Crazypacket.Commands =
 
 // --------------------------------------------
 // chainable write methods
+// This is sugar so you never have to resize your buffer & to track how many
+// bytes we need to write over the radio.
+
+
+Crazypacket.prototype.writeType = function(type, value)
+{
+	switch(type)
+	{
+	case 'uint8_t':
+		return this.writeByte(value);
+
+	case 'uint16_t':
+		return this.writeUnsignedShort(value);
+
+	case 'uint32_t':
+		return this.writeUnsignedLong(value);
+
+	case 'uint64_t':
+		return this.writeUnsignedLongLong(value);
+
+	case 'int8_t':
+		return this.writeInt(value);
+
+	case 'int16_t':
+		return this.writeShort(value);
+
+	case 'int32_t':
+		return this.writeLong(value);
+
+	case 'int64_t':
+		return this.writeLongLong(value);
+
+	case 'float':
+		return this.writeFloat(value);
+
+	case 'double':
+		return this.writeDouble(value);
+
+	default:
+		// log?
+		return this;
+	}
+};
 
 Crazypacket.prototype.resizeBuffer = function()
 {
@@ -77,16 +123,17 @@ Crazypacket.prototype.writeFloat = function(value)
 	return this;
 };
 
-Crazypacket.prototype.writeUnsignedShort = function(value)
+Crazypacket.prototype.writeDouble = function(value)
 {
 	if (!this._writable)
 		return;
-	if (this.pointer + 2 >= this.data.length)
+	if (this.pointer + 8 >= this.data.length)
 		this.resizeBuffer();
 
-	this.data.writeUInt16LE(value, this.pointer);
-	this.pointer += 2;
+	this.data.writeDoubleLE(value, this.pointer);
+	this.pointer += 8;
 	return this;
+
 };
 
 Crazypacket.prototype.writeByte = function(value)
@@ -101,6 +148,93 @@ Crazypacket.prototype.writeByte = function(value)
 	return this;
 };
 
+Crazypacket.prototype.writeUnsignedShort = function(value)
+{
+	if (!this._writable)
+		return;
+	if (this.pointer + 2 >= this.data.length)
+		this.resizeBuffer();
+
+	this.data.writeUInt16LE(value, this.pointer);
+	this.pointer += 2;
+	return this;
+};
+
+Crazypacket.prototype.writeUnsignedLong = function(value)
+{
+	if (!this._writable)
+		return;
+	if (this.pointer + 4 >= this.data.length)
+		this.resizeBuffer();
+
+	this.data.writeUInt32LE(value, this.pointer);
+	this.pointer += 4;
+	return this;
+};
+
+Crazypacket.prototype.writeUnsignedLongLong = function(value)
+{
+	if (!this._writable)
+		return;
+	if (this.pointer + 8 >= this.data.length)
+		this.resizeBuffer();
+
+	this.data.writeUInt64LE(value, this.pointer);
+	this.pointer += 8;
+	return this;
+};
+
+//
+
+Crazypacket.prototype.writeInt = function(value)
+{
+	if (!this._writable)
+		return;
+	if (this.pointer + 1 >= this.data.length)
+		this.resizeBuffer();
+
+	this.data.writeInt8(value, this.pointer);
+	this.pointer++;
+	return this;
+};
+
+Crazypacket.prototype.writeShort = function(value)
+{
+	if (!this._writable)
+		return;
+	if (this.pointer + 2 >= this.data.length)
+		this.resizeBuffer();
+
+	this.data.writeInt16LE(value, this.pointer);
+	this.pointer += 2;
+	return this;
+};
+
+Crazypacket.prototype.writeLong = function(value)
+{
+	if (!this._writable)
+		return;
+	if (this.pointer + 4 >= this.data.length)
+		this.resizeBuffer();
+
+	this.data.writeInt32LE(value, this.pointer);
+	this.pointer += 4;
+	return this;
+};
+
+Crazypacket.prototype.writeLongLong = function(value)
+{
+	if (!this._writable)
+		return;
+	if (this.pointer + 8 >= this.data.length)
+		this.resizeBuffer();
+
+	this.data.writeInt64LE(value, this.pointer);
+	this.pointer += 8;
+	return this;
+};
+
+// ready to write over the radio...
 Crazypacket.prototype.endPacket = function()
 {
 	if (!this._writable)

--- a/lib/crazyradio.js
+++ b/lib/crazyradio.js
@@ -116,7 +116,6 @@ Crazyradio.prototype.setupRadio = function(device, channel, datarate)
 
 	var input = this.inputStream();
 	input.addListener('readable', this.onReadable.bind(this));
-	input.addListener('end', this.onInputEnd.bind(this));
 	input.addListener('error', this.onInputError.bind(this));
 
 	this.pingTimer = setTimeout(this.ping(), 5000);
@@ -351,6 +350,12 @@ Crazyradio.prototype.onInputEnd = function()
 Crazyradio.prototype.onInputError = function(err)
 {
 	console.log('usb stream input error:', err);
+	this.close()
+	.then(function()
+	{
+		console.log('shutting down following usb error.');
+		process.exit(0);
+	});
 };
 
 Crazyradio.prototype.write = function(data, timeout)
@@ -359,7 +364,6 @@ Crazyradio.prototype.write = function(data, timeout)
 		deferred = P.defer();
 
 	var d = domain.create();
-
 	d.on('error', function(err)
 	{
 		deferred.reject(err);

--- a/lib/crazyradio.js
+++ b/lib/crazyradio.js
@@ -33,9 +33,6 @@ var P_M12DBM = 1;
 var P_M6DBM  = 2;
 var P_0DBM   = 3;
 
-
-// ----- The radio driver
-
 function findCrazyradios()
 {
 	// Return a list of radios attached to the host
@@ -62,7 +59,7 @@ var Crazyradio = module.exports = function Crazyradio()
 	this.datarate = 2;
 
 	this.pingTimer = null;
-}
+};
 util.inherits(Crazyradio, events.EventEmitter);
 
 

--- a/lib/crazyradio.js
+++ b/lib/crazyradio.js
@@ -7,6 +7,7 @@ var
 	util              = require('util'),
 	P                 = require('p-promise'),
 	Crazypacket       = require('./crazypacket'),
+	Protocol          = require('./protocol'),
 	usbstreams        = require('./usbstreams'),
 	WritableUSBStream = usbstreams.WritableUSBStream,
 	ReadableUSBStream = usbstreams.ReadableUSBStream
@@ -317,23 +318,23 @@ Crazyradio.prototype.onReadable = function()
 
 	switch (ack.packet.port)
 	{
-	case Crazypacket.Ports.CONSOLE:
+	case Protocol.Ports.CONSOLE:
 		this.emit('console', ack.packet);
 		break;
 
-	case Crazypacket.Ports.PARAM:
+	case Protocol.Ports.PARAM:
 		this.emit('param', ack.packet);
 		break;
 
-	case Crazypacket.Ports.COMMANDER:
+	case Protocol.Ports.COMMANDER:
 		this.emit('commander', ack.packet);
 		break;
 
-	case Crazypacket.Ports.LOGGING:
+	case Protocol.Ports.LOGGING:
 		this.emit('logging', ack.packet);
 		break;
 
-	case Crazypacket.Ports.LINKCTRL:
+	case Protocol.Ports.LINKCTRL:
 		this.emit('linkcontrol', ack);
 		break;
 

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -24,38 +24,66 @@ function Parameters(driver)
 {
 	events.EventEmitter.call(this);
 
-	this.driver    = driver;
-	this.total     = 0;
-	this.variables = {};
-	this.CRC       = null;
-	this.deferreds = [];
+	this.driver       = driver;
+	this.total        = 0;
+	this.variables    = {};
+	this.idToName     = {};
+	this.CRC          = null;
+	this.getDeferreds = {};
+	this.setDeferreds = {};
 }
 util.inherits(Parameters, events.EventEmitter);
 
 Parameters.prototype.all = function()
 {
 	// TODO: return a hash of all params & values
+	return this.variables;
 };
 
 Parameters.prototype.get = function(name)
 {
 	if (this.variables[name])
-		return P(this.variables[name].value);
+		return this.variables[name].value;
+};
 
-	/* TODO fetch it from the copter
-		sketch:
-		make a deferred array for this name if one doesn't exist
-		add a new deferred to the array
-		fire off a parameter request
-		when that parameter comes back in, resolve all the deferreds in its list
-		with the new value
-	*/
+Parameters.prototype.update = function(name)
+{
+	var deferred = P.defer();
+
+	if (!this.variables[name])
+	{
+		deferred.reject(new Error('unknown parameter: ' + name));
+		return deferred.promise;
+	}
+
+	if (!this.getDeferreds[name])
+		this.getDeferreds[name] = [];
+	this.getDeferreds[name].push(deferred);
+
+	var parameter = this.variables[name];
+	this.driver.getParameter(parameter.id);
+
+	return deferred.promise;
 };
 
 Parameters.prototype.set = function(name, value)
 {
-	// TODO: set the value of a single parameter
-	// resolve the promise when the ack has returned
+	var deferred = P.defer();
+
+	if (!this.variables[name])
+	{
+		deferred.reject(new Error('unknown parameter: ' + name));
+		return deferred.promise;
+	}
+
+	if (!this.setDeferreds[name])
+		this.setDeferreds[name] = [];
+	this.setDeferreds[name].push(deferred);
+
+	var parameter = this.variables[name];
+	this.driver.setParameter(parameter, value);
+
+	return deferred.promise;
 };
 
 Parameters.prototype.handlePacket = function(packet)
@@ -83,6 +111,37 @@ Parameters.prototype.handlePacket = function(packet)
 	}
 };
 
+Parameters.prototype.handleRead = function(payload)
+{
+	var id = payload[0];
+	var name = this.idToName[id];
+	if (!name)
+	{
+		console.log('cannot find param for id ' + id);
+		return;
+	}
+
+	var param = this.variables[name];
+	param.value = Crazypacket.readType(payload, param.type, 1);
+
+	var deferreds = this.setDeferreds[name];
+	for (var i = 0; i < deferreds.length; i++)
+		deferreds[i].resolve(param.value);
+	this.setDeferreds[name] = [];
+};
+
+Parameters.prototype.handleWrite = function(payload)
+{
+	var id = payload[0];
+	var name = this.idToName[id];
+	var param = this.variables[name];
+
+	var deferreds = this.setDeferreds[name];
+	for (var i = 0; i < deferreds.length; i++)
+		deferreds[i].resolve(param.value);
+	this.setDeferreds[name] = [];
+};
+
 // Refactoring opportunity: this is exactly parallel to the telemetry pattern.
 
 Parameters.prototype.handleTOCElement = function(payload)
@@ -91,7 +150,6 @@ Parameters.prototype.handleTOCElement = function(payload)
 		return;
 
 	var ptr = 1;
-	// var next = payload[1];
 	var item = new Parameter();
 	item.id = payload[ptr++];
 	item.type = payload[ptr++];
@@ -107,8 +165,8 @@ Parameters.prototype.handleTOCElement = function(payload)
 	item.name = payload.slice(start, ptr).toString();
 
 	item.fullname = item.group + '.' + item.name;
-	// console.log('telemetry variable: ' + item.fullname, item.id, item.type);
-	this.variables[item.fullname] = item;
+	this.variables[item.name] = item;
+	this.nameToID[item.id] = item.name;
 
 	if (item.id < this.total)
 		this.driver.requestParameter(item.id + 1);
@@ -118,7 +176,7 @@ Parameters.prototype.handleTOCInfo = function(payload)
 {
 	this.total = payload[1];
 	this.CRC   = payload.slice(2);
-	this.driver.requestTelemetryElement(0);
+	this.driver.requestParameter(0);
 };
 
 

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -42,8 +42,14 @@ Parameters.prototype.all = function()
 
 Parameters.prototype.get = function(name)
 {
-	if (this.variables[name])
-		return this.variables[name].value;
+	if (!this.variables[name])
+		return P('unknown');
+
+	var param = this.variables[name];
+	if (!_.isUndefined(param.value))
+		return P(param.value);
+
+	return this.update(name);
 };
 
 Parameters.prototype.update = function(name)
@@ -124,7 +130,10 @@ Parameters.prototype.handleRead = function(payload)
 	var param = this.variables[name];
 	param.value = Crazypacket.readType(payload, param.type, 1);
 
-	var deferreds = this.setDeferreds[name];
+	var deferreds = this.getDeferreds[name];
+	if (!deferreds)
+		return;
+
 	for (var i = 0; i < deferreds.length; i++)
 		deferreds[i].resolve(param.value);
 	this.setDeferreds[name] = [];
@@ -137,6 +146,9 @@ Parameters.prototype.handleWrite = function(payload)
 	var param = this.variables[name];
 
 	var deferreds = this.setDeferreds[name];
+	if (!deferreds)
+		return;
+
 	for (var i = 0; i < deferreds.length; i++)
 		deferreds[i].resolve(param.value);
 	this.setDeferreds[name] = [];

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -1,0 +1,134 @@
+// Parameters, aka Crazyflie copter settings.
+
+var
+	_           = require('lodash'),
+	events      = require('events'),
+	util        = require('util'),
+	P           = require('p-promise'),
+	Crazypacket = require('./crazypacket')
+	;
+
+var DataTypes =
+{
+	1: 'uint8_t',
+	2: 'uint16_t',
+	3: 'uint32_t',
+	4: 'int8_t',
+	5: 'int16_t',
+	6: 'int32_t',
+	7: 'float32',
+	8: 'float16'
+};
+
+function Parameters(driver)
+{
+	events.EventEmitter.call(this);
+
+	this.driver    = driver;
+	this.total     = 0;
+	this.variables = {};
+	this.CRC       = null;
+	this.deferreds = [];
+}
+util.inherits(Parameters, events.EventEmitter);
+
+Parameters.prototype.all = function()
+{
+	// TODO: return a hash of all params & values
+};
+
+Parameters.prototype.get = function(name)
+{
+	if (this.variables[name])
+		return P(this.variables[name].value);
+
+	/* TODO fetch it from the copter
+		sketch:
+		make a deferred array for this name if one doesn't exist
+		add a new deferred to the array
+		fire off a parameter request
+		when that parameter comes back in, resolve all the deferreds in its list
+		with the new value
+	*/
+};
+
+Parameters.prototype.set = function(name, value)
+{
+	// TODO: set the value of a single parameter
+	// resolve the promise when the ack has returned
+};
+
+Parameters.prototype.handlePacket = function(packet)
+{
+	switch (packet.channel)
+	{
+	case Crazypacket.Channels.PARAM_TOC:
+		if (packet.payload[0] === Crazypacket.Commands.GET_ELEMENT)
+			this.handleTOCElement(packet.payload);
+		else
+			this.handleTOCInfo(packet.payload);
+		break;
+
+	case Crazypacket.Channels.PARAM_READ:
+		this.handleRead(packet.payload);
+		break;
+
+	case Crazypacket.Channels.PARAM_WRITE:
+		this.handleWrite(packet.payload);
+		break;
+
+	default:
+		console.log('unhandled packet', packet.header, packet.payload);
+		break;
+	}
+};
+
+// Refactoring opportunity: this is exactly parallel to the telemetry pattern.
+
+Parameters.prototype.handleTOCElement = function(payload)
+{
+	if (payload.length < 2)
+		return;
+
+	var ptr = 1;
+	// var next = payload[1];
+	var item = new Parameter();
+	item.id = payload[ptr++];
+	item.type = payload[ptr++];
+
+	var start = ptr;
+	while (payload[ptr] !== 0x00)
+		ptr++;
+	item.group = payload.slice(start, ptr).toString();
+
+	start = ++ptr;
+	while (payload[ptr] !== 0x00)
+		ptr++;
+	item.name = payload.slice(start, ptr).toString();
+
+	item.fullname = item.group + '.' + item.name;
+	// console.log('telemetry variable: ' + item.fullname, item.id, item.type);
+	this.variables[item.fullname] = item;
+
+	if (item.id < this.total)
+		this.driver.requestParameter(item.id + 1);
+};
+
+Parameters.prototype.handleTOCInfo = function(payload)
+{
+	this.total = payload[1];
+	this.CRC   = payload.slice(2);
+	this.driver.requestTelemetryElement(0);
+};
+
+
+function Parameter()
+{
+	this.id       = null;
+	this.type     = null;
+	this.group    = '';
+	this.name     = '';
+	this.fullname = '';
+	this.readonly = false;
+}
+

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -20,7 +20,7 @@ var DataTypes =
 	8: 'float16'
 };
 
-function Parameters(driver)
+var Parameters = module.exports = function Parameters(driver)
 {
 	events.EventEmitter.call(this);
 
@@ -142,43 +142,31 @@ Parameters.prototype.handleWrite = function(payload)
 	this.setDeferreds[name] = [];
 };
 
-// Refactoring opportunity: this is exactly parallel to the telemetry pattern.
-
 Parameters.prototype.handleTOCElement = function(payload)
 {
 	if (payload.length < 2)
 		return;
 
-	var ptr = 1;
 	var item = new Parameter();
-	item.id = payload[ptr++];
-	item.type = payload[ptr++];
+	item.read(payload);
 
-	var start = ptr;
-	while (payload[ptr] !== 0x00)
-		ptr++;
-	item.group = payload.slice(start, ptr).toString();
+	this.variables[item.fullname] = item;
+	this.idToName[item.id] = item.fullname;
 
-	start = ++ptr;
-	while (payload[ptr] !== 0x00)
-		ptr++;
-	item.name = payload.slice(start, ptr).toString();
-
-	item.fullname = item.group + '.' + item.name;
-	this.variables[item.name] = item;
-	this.nameToID[item.id] = item.name;
+	console.log('param: '+item.id, item.fullname);
 
 	if (item.id < this.total)
 		this.driver.requestParameter(item.id + 1);
+	else
+		this.driver.parametersDone();
 };
 
 Parameters.prototype.handleTOCInfo = function(payload)
 {
-	this.total = payload[1];
-	this.CRC   = payload.slice(2);
+	this.total = payload[1] - 1;
+	this.CRC = payload.readUInt16LE(2);
 	this.driver.requestParameter(0);
 };
-
 
 function Parameter()
 {
@@ -189,4 +177,23 @@ function Parameter()
 	this.fullname = '';
 	this.readonly = false;
 }
+
+Parameter.prototype.read = function(payload)
+{
+	var ptr = 1;
+	this.id = payload[ptr++];
+	this.type = payload[ptr++];
+
+	var start = ptr;
+	while (payload[ptr] !== 0x00)
+		ptr++;
+	this.group = payload.slice(start, ptr).toString();
+
+	start = ++ptr;
+	while (payload[ptr] !== 0x00)
+		ptr++;
+	this.name = payload.slice(start, ptr).toString();
+
+	this.fullname = this.group + '.' + this.name;
+};
 

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -5,7 +5,8 @@ var
 	events      = require('events'),
 	util        = require('util'),
 	P           = require('p-promise'),
-	Crazypacket = require('./crazypacket')
+	Crazypacket = require('./crazypacket'),
+	Protocol    = require('./protocol')
 	;
 
 var DataTypes =
@@ -31,7 +32,7 @@ var Parameters = module.exports = function Parameters(driver)
 	this.CRC          = null;
 	this.getDeferreds = {};
 	this.setDeferreds = {};
-}
+};
 util.inherits(Parameters, events.EventEmitter);
 
 Parameters.prototype.all = function()
@@ -96,18 +97,18 @@ Parameters.prototype.handlePacket = function(packet)
 {
 	switch (packet.channel)
 	{
-	case Crazypacket.Channels.PARAM_TOC:
-		if (packet.payload[0] === Crazypacket.Commands.GET_ELEMENT)
+	case Protocol.Channels.PARAM_TOC:
+		if (packet.payload[0] === Protocol.Commands.GET_ELEMENT)
 			this.handleTOCElement(packet.payload);
 		else
 			this.handleTOCInfo(packet.payload);
 		break;
 
-	case Crazypacket.Channels.PARAM_READ:
+	case Protocol.Channels.PARAM_READ:
 		this.handleRead(packet.payload);
 		break;
 
-	case Crazypacket.Channels.PARAM_WRITE:
+	case Protocol.Channels.PARAM_WRITE:
 		this.handleWrite(packet.payload);
 		break;
 
@@ -122,12 +123,12 @@ Parameters.prototype.handleRead = function(payload)
 	var id = payload[0];
 	var name = this.idToName[id];
 	if (!name)
-	{
-		console.log('cannot find param for id ' + id);
 		return;
-	}
 
 	var param = this.variables[name];
+	if (!param)
+		return;
+
 	param.value = Crazypacket.readType(payload, param.type, 1);
 
 	var deferreds = this.getDeferreds[name];
@@ -136,7 +137,7 @@ Parameters.prototype.handleRead = function(payload)
 
 	for (var i = 0; i < deferreds.length; i++)
 		deferreds[i].resolve(param.value);
-	this.setDeferreds[name] = [];
+	this.getDeferreds[name] = [];
 };
 
 Parameters.prototype.handleWrite = function(payload)

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -1,0 +1,34 @@
+var Crazyprotocol = module.exports = {};
+
+Crazyprotocol.Ports =
+{
+	CONSOLE     : 0x00,
+	PARAM       : 0x02,
+	COMMANDER   : 0x03,
+	LOGGING     : 0x05,
+	DEBUGDRIVER : 0x0E,
+	LINKCTRL    : 0x0F,
+	ALL         : 0xFF,
+};
+
+Crazyprotocol.Channels =
+{
+	TOC:      0,
+	SETTINGS: 1,
+	LOGDATA:  2,
+	PARAM_TOC: 0,
+	PARAM_READ: 1,
+	PARAM_WRITE: 2,
+};
+
+Crazyprotocol.Commands =
+{
+	CREATE_BLOCK:  0,
+	APPEND_BLOCK:  1,
+	DELETE_BLOCK:  2,
+	START_LOGGING: 3,
+	STOP_LOGGING:  4,
+	RESET_LOGGING: 5,
+	GET_ELEMENT:   0,
+	GET_INFO:      1
+};

--- a/lib/telemetry.js
+++ b/lib/telemetry.js
@@ -31,6 +31,7 @@ function Telemetry(driver)
 	this.CRC             = null;
 	this.motorblock      = null;
 	this.stabilizerblock = null;
+	this.accblock        = null;
 	this.nextBlockID     = 16;
 	this.blocks          = {};
 }
@@ -120,11 +121,15 @@ Telemetry.prototype.handleBlock = function(payload)
 	switch (payload[0])
 	{
 	case this.motorblock:
-		this.handleMotorTelemetry(payload);
+		this.handleMotor(payload);
 		break;
 
 	case this.stabilizerblock:
-		this.handleStabilizerTelemetry(payload);
+		this.handleStabilizer(payload);
+		break;
+
+	case this.accblock:
+		this.handleAccelerometer(payload);
 		break;
 
 	default:
@@ -146,6 +151,17 @@ Telemetry.prototype.subscribe = function(group, subfunc)
 		this.startStabilizer();
 		this.addListener('stabilizer', subfunc);
 		break;
+
+	case 'accelerometer':
+		if (!this.variables['acc.x'])
+		{
+			console.log('** no accelerometer telemetry available');
+			return;
+		}
+		this.startAccelerometer();
+		this.addListener('accelerometer', subfunc);
+		break;
+
 
 	default:
 		console.error('warning: cannot subscribe to non-existent telemetry group ' + group);
@@ -204,7 +220,32 @@ Telemetry.prototype.startStabilizer = function()
 	}).done();
 };
 
-Telemetry.prototype.handleMotorTelemetry = function(payload)
+Telemetry.prototype.startAccelerometer = function()
+{
+	var self = this;
+	if (this.accblock)
+		return;
+
+	var block =
+	{
+		id: this.nextBlockID++,
+		variables:
+		[
+			{ fetchAs: 7, type: this.variables['acc.x'].type, id: this.variables['acc.x'].id },
+			{ fetchAs: 7, type: this.variables['acc.y'].type, id: this.variables['acc.y'].id },
+			{ fetchAs: 7, type: this.variables['acc.z'].type, id: this.variables['acc.z'].id },
+		],
+	};
+
+	this.driver.createTelemetryBlock(block)
+	.then(function()
+	{
+		self.accblock = block.id;
+		self.driver.enableTelemetryBlock(block.id);
+	}).done();
+};
+
+Telemetry.prototype.handleMotor = function(payload)
 {
 	var update =
 	{
@@ -216,15 +257,26 @@ Telemetry.prototype.handleMotorTelemetry = function(payload)
 	this.emit('motor', update);
 };
 
-Telemetry.prototype.handleStabilizerTelemetry = function(payload)
+Telemetry.prototype.handleStabilizer = function(payload)
 {
 	var update =
 	{
-		roll: payload.readFloatLE(4),
+		roll:  payload.readFloatLE(4),
 		pitch: payload.readFloatLE(8),
-		yaw: payload.readFloatLE(12)
+		yaw:   payload.readFloatLE(12)
 	};
 	this.emit('stabilizer', update);
+};
+
+Telemetry.prototype.handleAccelerometer = function(payload)
+{
+	var update =
+	{
+		x: payload.readFloatLE(4),
+		y: payload.readFloatLE(8),
+		z: payload.readFloatLE(12)
+	};
+	this.emit('accelerometer', update);
 };
 
 function TelemetryDatum()

--- a/lib/telemetry.js
+++ b/lib/telemetry.js
@@ -66,24 +66,10 @@ Telemetry.prototype.handleTOCElement = function(payload)
 	if (payload.length < 2)
 		return this.driver.telemetryReady();
 
-	var ptr = 1;
-	// var next = payload[1];
 	var item = new TelemetryDatum();
-	item.id = payload[ptr++];
-	item.type = payload[ptr++];
+	item.read(payload);
 
-	var start = ptr;
-	while (payload[ptr] !== 0x00)
-		ptr++;
-	item.group = payload.slice(start, ptr).toString();
-
-	start = ++ptr;
-	while (payload[ptr] !== 0x00)
-		ptr++;
-	item.name = payload.slice(start, ptr).toString();
-
-	item.fullname = item.group + '.' + item.name;
-	// console.log('telemetry variable: ' + item.fullname, item.id, item.type);
+	console.log('telemetry: ' + item.fullname, item.id, item.type);
 	this.variables[item.fullname] = item;
 
 	if (item.id < this.total)
@@ -94,8 +80,8 @@ Telemetry.prototype.handleTOCElement = function(payload)
 
 Telemetry.prototype.handleTOCInfo = function(payload)
 {
-	this.total = payload[1];
-	this.CRC   = payload.slice(2);
+	this.total = payload[1] - 1;
+	this.CRC = payload.readUInt16LE(2);
 	this.driver.requestTelemetryElement(0);
 };
 
@@ -249,5 +235,24 @@ function TelemetryDatum()
 	this.name     = '';
 	this.fullname = '';
 }
+
+TelemetryDatum.prototype.read = function(payload)
+{
+	var ptr = 1;
+	this.id = payload[ptr++];
+	this.type = payload[ptr++];
+
+	var start = ptr;
+	while (payload[ptr] !== 0x00)
+		ptr++;
+	this.group = payload.slice(start, ptr).toString();
+
+	start = ++ptr;
+	while (payload[ptr] !== 0x00)
+		ptr++;
+	this.name = payload.slice(start, ptr).toString();
+
+	this.fullname = this.group + '.' + this.name;
+};
 
 module.exports = Telemetry;

--- a/lib/telemetry.js
+++ b/lib/telemetry.js
@@ -147,7 +147,7 @@ Telemetry.prototype.handleBlock = function(payload)
 };
 
 
-Telemetry.prototype.addSubscriber = function(subfunc, group)
+Telemetry.prototype.subscribe = function(group, subfunc)
 {
 	switch (group)
 	{

--- a/lib/telemetry.js
+++ b/lib/telemetry.js
@@ -6,7 +6,7 @@ var
 	events      = require('events'),
 	util        = require('util'),
 	P           = require('p-promise'),
-	Crazypacket = require('./crazypacket')
+	Protocol    = require('./protocol')
 	;
 
 var DataTypes =
@@ -40,18 +40,18 @@ Telemetry.prototype.handlePacket = function(packet)
 {
 	switch (packet.channel)
 	{
-	case Crazypacket.Channels.TOC:
-		if (packet.payload[0] === Crazypacket.Commands.GET_ELEMENT)
+	case Protocol.Channels.TOC:
+		if (packet.payload[0] === Protocol.Commands.GET_ELEMENT)
 			this.handleTOCElement(packet.payload);
 		else
 			this.handleTOCInfo(packet.payload);
 		break;
 
-	case Crazypacket.Channels.SETTINGS:
+	case Protocol.Channels.SETTINGS:
 		this.handleSettings(packet.payload);
 		break;
 
-	case Crazypacket.Channels.LOGDATA:
+	case Protocol.Channels.LOGDATA:
 		this.handleBlock(packet.payload);
 		break;
 
@@ -89,27 +89,27 @@ Telemetry.prototype.handleSettings = function(payload)
 {
 	switch (payload[0])
 	{
-	case Crazypacket.Commands.CREATE_BLOCK:
+	case Protocol.Commands.CREATE_BLOCK:
 		//console.log('telemetry block ' + payload[1] + ' created: ' + (payload[2] === 0));
 		break;
 
-	case Crazypacket.Commands.APPEND_BLOCK:
+	case Protocol.Commands.APPEND_BLOCK:
 		console.log('telemetry block ' + payload[1] + ' appended to: ' + (payload[2] === 0));
 		break;
 
-	case Crazypacket.Commands.DELETE_BLOCK:
+	case Protocol.Commands.DELETE_BLOCK:
 		console.log('telemetry block ' + payload[1] + ' deleted: ' + (payload[2] === 0));
 		break;
 
-	case Crazypacket.Commands.START_LOGGING:
+	case Protocol.Commands.START_LOGGING:
 		// console.log('telemetry block ' + payload[1] + ' enabled: ' + (payload[2] === 0));
 		break;
 
-	case Crazypacket.Commands.STOP_LOGGING:
+	case Protocol.Commands.STOP_LOGGING:
 		console.log('telemetry block ' + payload[1] + ' stopped: ' + (payload[2] === 0));
 		break;
 
-	case Crazypacket.Commands.RESET_LOGGING:
+	case Protocol.Commands.RESET_LOGGING:
 		// console.log('telemetry reset: ' + payload.slice(1));
 		break;
 	}

--- a/lib/usbstreams.js
+++ b/lib/usbstreams.js
@@ -44,14 +44,12 @@ ReadableUSBStream.prototype.onError = function(error)
 {
 	// TODO
 	console.log(error);
-	this.endpoint.stopStream();
 };
 
 ReadableUSBStream.prototype.onEnd = function()
 {
 	// TODO
 	console.log('readable stream end');
-	this.endpoint.stopStream();
 };
 
 // ----- Wrap the node-usb outgoing stream-like-object with new node streams

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name":        "aerogel",
-	"version":     "0.0.2",
+	"version":     "0.0.3",
 	"description": "CrazyFlie control software",
 	"author":      "C J Silverio <ceejceej@gmail.com>",
 	"license":     "MIT",


### PR DESCRIPTION
This branch adds support for reading two new kinds of data from the copter.

If your copter is a 10DOF with firmware that supports the accelerometer on that build, you can do something with the 'accelerometer' events from the telemetry module. `copter.js` has a handler that does nothing but log.

Also, implemented basic support for reading copter parameters, that is, settings from the device. I have not yet tested setting parameters, though that might work. 

Bumped version in preparation for a fresh push to npm.
